### PR TITLE
Fix the "Not Secure" sign on location bar.

### DIFF
--- a/_posts/2012-04-22-rx-for-go-headaches.md
+++ b/_posts/2012-04-22-rx-for-go-headaches.md
@@ -12,7 +12,7 @@ There has been a lot of discussion on the [Go Nuts](https://groups.google.com/fo
 
 TL;DR: [kylelemons.net/go/rx](http://kylelemons.net/go/rx)
 
-![Relevant XKCD (online package tracking)](http://imgs.xkcd.com/comics/online_package_tracking.png)
+![Relevant XKCD (online package tracking)](https://imgs.xkcd.com/comics/online_package_tracking.png)
 
 _Oddly appropriate, don't you think?_
 


### PR DESCRIPTION
Needs to fetch image from https to appear green.

Error in console shows that:
> Mixed Content: The page at 'https://kylelemons.net/' was loaded over HTTPS, but requested an insecure image 'http://imgs.xkcd.com/comics/online_package_tracking.png'. This content should also be served over HTTPS.